### PR TITLE
Add argon2-cffi-bindings 21.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,26 +10,22 @@ source:
   sha256: "bb89ceffa6c791807d1305ceb77dbfacc5aa499891d2c55661c6459651fc39e3"
 
 build:
-  number: 1
+  number: 0
+  skip: True  # [py<36]
   script:
     - ln -sf $RANLIB $BUILD_PREFIX/bin/ranlib  # [unix]
     - {{ PYTHON }} -m pip install . -vv
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cffi >=1.0.1                           # [build_platform != target_platform]
     - {{ compiler("c") }}
-
   host:
     - python
-    - pip
     - cffi >=1.0.1
+    - pip
     - setuptools >=45
     - setuptools_scm >=6.2
     - wheel
-
   run:
     - python
     - cffi >=1.0.1


### PR DESCRIPTION
`argon2-cffi 21.3.0` requires `argon2-cffi-bindings 21.2.0`

Changelog: https://github.com/hynek/argon2-cffi-bindings/blob/21.2.0/CHANGELOG.md
License: https://github.com/hynek/argon2-cffi-bindings/blob/21.2.0/LICENSE
Requirements:
- https://github.com/hynek/argon2-cffi-bindings/blob/21.2.0/pyproject.toml
- https://github.com/hynek/argon2-cffi-bindings/blob/21.2.0/setup.py

Action:
1. Reset build number to `0`
2. Skip `py<36`
3. Remove cross-compiling from `build`